### PR TITLE
modified firebase emulator settings and some log levels

### DIFF
--- a/packages/binding-firestore/test/firebase.json
+++ b/packages/binding-firestore/test/firebase.json
@@ -5,10 +5,13 @@
             "host": "127.0.0.1"
         },
         "ui": {
-            "enabled": true
+            "enabled": true,
+            "port": 4000,
+            "host": "127.0.0.1"
         },
         "auth": {
-            "port": 9099
+            "port": 9099,
+            "host": "127.0.0.1"
         }
     },
     "firestore": {

--- a/packages/binding-firestore/test/test-thing.ts
+++ b/packages/binding-firestore/test/test-thing.ts
@@ -42,7 +42,7 @@ export const launchTestThing = async (): Promise<WoT.ExposedThing | void> => {
                     .createUserWithEmailAndPassword(firestoreConfig.user.email, firestoreConfig.user.password);
             } catch (e) {
                 // is not error
-                error(`user ia already created err: ${e}`);
+                info(`user is already created err: ${e}`);
             }
         }
         // create server
@@ -270,6 +270,6 @@ export const launchTestThing = async (): Promise<WoT.ExposedThing | void> => {
         info(`${thing.getThingDescription().title} ready`);
         return thing;
     } catch (err) {
-        debug(err);
+        error(err);
     }
 };


### PR DESCRIPTION
I believe the binding-firestore test now passes in nodejs18.
I also hope that I specified the host in the firebase emulator configuration so that the timeout does not occur.